### PR TITLE
feat(client): expose execute method for custom Odoo operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,23 @@ Delete records.
 
 Get field information for a model.
 
+#### `async execute<T>(model: string, method: string, args?: any[], kwargs?: object): Promise<T>`
+
+Execute any method on an Odoo model. This is useful for calling custom methods or workflow actions.
+
+```typescript
+// Example: Confirm a sale order
+await client.execute('sale.order', 'action_confirm', [orderId]);
+
+// Example: Send email using template
+await client.execute('mail.template', 'send_mail', [templateId, recordId]);
+
+// Example: Custom method with keyword arguments
+await client.execute('your.model', 'your_method', [arg1, arg2], {
+  kwarg1: 'value1',
+  kwarg2: 'value2'
+});
+
 ## Error Handling
 
 The client includes built-in error classes:

--- a/src/client.ts
+++ b/src/client.ts
@@ -69,7 +69,7 @@ export class OdooClient {
     }
   }
 
-  private async execute<T>(
+  public async execute<T>(
     model: string,
     method: string,
     args: any[] = [],


### PR DESCRIPTION
- Change execute method visibility from private to public
- Allow direct access to custom Odoo model methods and workflows
- Update README with execute method documentation and examples

This change enables users to call any custom Odoo method beyond CRUD operations, such as workflow actions (action_confirm), business logic methods, or custom implementations on Odoo models.

BREAKING CHANGE: execute method is now part of the public API