### PR TITLE
feat: support custom HTTP agents for XML-RPC connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,38 @@ async function example() {
 }
 ```
 
+### HTTP Agent Configuration
+
+You can configure custom HTTP agents for advanced network configurations such as custom SSL settings, or connection pooling:
+
+```typescript
+import { OdooClient } from 'odoo-xmlrpc-ts';
+import https from 'node:https';
+import fs from 'node:fs';
+
+// Example: Custom HTTPS agent with specific SSL options
+const httpsAgent = new https.Agent({
+  ca: fs.readFileSync('/path/to/ca-certificate.pem'), // Custom CA certificate
+  keepAlive: true,
+  maxSockets: 10,
+});
+
+// Alternative: For development/testing only (not recommended for production)
+const httpsAgent = new https.Agent({
+  rejectUnauthorized: false, // Disables SSL verification (use only for testing)
+  keepAlive: true,
+  maxSockets: 10,
+});
+
+const client = new OdooClient({
+  url: 'https://your-odoo-instance.com',
+  db: 'your-database',
+  username: 'admin',
+  password: 'admin',
+  agent: httpsAgent,
+});
+```
+
 ### Advanced Usage
 
 ```typescript
@@ -146,6 +178,7 @@ const client = new OdooClient({
   db: string;     // Database name
   username: string;
   password: string;
+  agent?: https.Agent | http.Agent;  // Optional HTTP agent for custom network configuration
 });
 ```
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,8 +24,12 @@ export class OdooClient {
 
     const createClient = protocol === 'https' ? xmlrpc.createSecureClient : xmlrpc.createClient;
 
-    this.common = createClient(`${config.url}/xmlrpc/2/common`);
-    this.object = createClient(`${config?.url}/xmlrpc/2/object`);
+    const clientOptions = {
+      agent: config.agent,
+    };
+
+    this.common = createClient({ ...clientOptions, url: `${config.url}/xmlrpc/2/common` });
+    this.object = createClient({ ...clientOptions, url: `${config.url}/xmlrpc/2/object` });
   }
 
   private methodCall<T>(client: xmlrpc.Client, method: string, params: any[]): Promise<T> {
@@ -130,7 +134,12 @@ export class OdooClient {
     return await this.execute(model, 'create', [values]);
   }
 
-  public async write<T extends object>(model: string, ids: number[], values: T, options: SearchOptions = {}): Promise<boolean> {
+  public async write<T extends object>(
+    model: string,
+    ids: number[],
+    values: T,
+    options: SearchOptions = {},
+  ): Promise<boolean> {
     return await this.execute(model, 'write', [ids, values], options);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,12 @@
+import https from 'node:https';
+import http from 'node:http';
+
 export interface OdooConfig {
   url: string;
   db: string;
   username: string;
   password: string;
+  agent?: https.Agent | http.Agent;
 }
 
 export interface OdooVersion {


### PR DESCRIPTION
## Description

This feature adds HTTP/HTTPS agent configuration support for Odoo XML-RPC connections.

This is useful when custom HTTP/HTTPS configuration is needed, such as SSL config (e.g. if the Odoo system target uses a default self signed certificate), or other connection (e.g. keepalive) / network settings.

###Example use case:

```ts
import { OdooClient } from 'odoo-xmlrpc-ts';
import https from 'node:https';

// Create custom agent with self signed certificate
const httpsAgent = new https.Agent({
  ca: fs.readFileSync('/path/to/odoo-ca.pem'),
  keepAlive: true,
});

const client = new OdooClient({
  url: 'https://your-odoo-instance.com',
  db: 'your-database',
  username: 'admin',
  password: 'admin',
  agent: httpsAgent, // Include the agent in the client config
});
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
